### PR TITLE
fix the  missing "yield" in line 158 of storageEngine.js

### DIFF
--- a/chrome/content/zotero/xpcom/storage/storageEngine.js
+++ b/chrome/content/zotero/xpcom/storage/storageEngine.js
@@ -155,7 +155,7 @@ Zotero.Sync.Storage.Engine.prototype.start = Zotero.Promise.coroutine(function* 
 			&& this.local.lastFullFileCheck[libraryID]
 			&& (this.local.lastFullFileCheck[libraryID]
 				+ (this.maxCheckAge * 1000)) > new Date().getTime()) {
-		let itemIDs = this.local.getFilesToCheck(libraryID, this.maxCheckAge);
+		let itemIDs = yield this.local.getFilesToCheck(libraryID, this.maxCheckAge);
 		yield this.local.checkForUpdatedFiles(libraryID, itemIDs);
 	}
 	// Otherwise check all files in library


### PR DESCRIPTION
Fix the issue where Zotero.Sync.Runner.sync({background: true}) cannot obtain the itemIDs